### PR TITLE
chore(ci): update actions to run on ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ jobs:
             kind: test_release
           - os: windows-2019
             kind: test_release
-          - os: ubuntu-16.04
+          - os: ubuntu-20.04
             kind: test_release
-          - os: ubuntu-16.04
+          - os: ubuntu-20.04
             kind: test_debug
-          - os: ubuntu-16.04
+          - os: ubuntu-20.04
             kind: bench
-          - os: ubuntu-16.04
+          - os: ubuntu-20.04
             kind: lint
 
       # Always run master branch builds to completion. This allows the cache to


### PR DESCRIPTION
<!--
Before submitting a PR, please read
https://github.com/denoland/deno/blob/master/docs/contributing.md
-->

Testing 20.04 instead of 18.04, as deno bench is timing out in https://github.com/trivikr/deno/pull/816